### PR TITLE
Suppress msvc and gcc/clang warnings

### DIFF
--- a/include/boost/asio/buffer.hpp
+++ b/include/boost/asio/buffer.hpp
@@ -707,7 +707,7 @@ public:
 
   void operator()()
   {
-    *iter_;
+    BOOST_ASIO_UNUSED_VARIABLE auto result = *iter_;
   }
 
 private:

--- a/test/generic/raw_protocol.cpp
+++ b/test/generic/raw_protocol.cpp
@@ -161,11 +161,11 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    rp::endpoint endpoint1 = socket1.local_endpoint();
-    rp::endpoint endpoint2 = socket1.local_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE rp::endpoint endpoint1 = socket1.local_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE rp::endpoint endpoint2 = socket1.local_endpoint(ec);
 
-    rp::endpoint endpoint3 = socket1.remote_endpoint();
-    rp::endpoint endpoint4 = socket1.remote_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE rp::endpoint endpoint3 = socket1.remote_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE rp::endpoint endpoint4 = socket1.remote_endpoint(ec);
 
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);

--- a/test/generic/stream_protocol.cpp
+++ b/test/generic/stream_protocol.cpp
@@ -177,11 +177,11 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    sp::endpoint endpoint1 = socket1.local_endpoint();
-    sp::endpoint endpoint2 = socket1.local_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE sp::endpoint endpoint1 = socket1.local_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE sp::endpoint endpoint2 = socket1.local_endpoint(ec);
 
-    sp::endpoint endpoint3 = socket1.remote_endpoint();
-    sp::endpoint endpoint4 = socket1.remote_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE sp::endpoint endpoint3 = socket1.remote_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE sp::endpoint endpoint4 = socket1.remote_endpoint(ec);
 
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);

--- a/test/ip/icmp.cpp
+++ b/test/ip/icmp.cpp
@@ -230,11 +230,11 @@ void test()
     socket1.native_non_blocking(true);
     socket1.native_non_blocking(false, ec);
 
-    ip::icmp::endpoint endpoint1 = socket1.local_endpoint();
-    ip::icmp::endpoint endpoint2 = socket1.local_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE ip::icmp::endpoint endpoint1 = socket1.local_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE ip::icmp::endpoint endpoint2 = socket1.local_endpoint(ec);
 
-    ip::icmp::endpoint endpoint3 = socket1.remote_endpoint();
-    ip::icmp::endpoint endpoint4 = socket1.remote_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE ip::icmp::endpoint endpoint3 = socket1.remote_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE ip::icmp::endpoint endpoint4 = socket1.remote_endpoint(ec);
 
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);

--- a/test/ip/tcp.cpp
+++ b/test/ip/tcp.cpp
@@ -378,11 +378,11 @@ void test()
     socket1.native_non_blocking(true);
     socket1.native_non_blocking(false, ec);
 
-    ip::tcp::endpoint endpoint1 = socket1.local_endpoint();
-    ip::tcp::endpoint endpoint2 = socket1.local_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE ip::tcp::endpoint endpoint1 = socket1.local_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE ip::tcp::endpoint endpoint2 = socket1.local_endpoint(ec);
 
-    ip::tcp::endpoint endpoint3 = socket1.remote_endpoint();
-    ip::tcp::endpoint endpoint4 = socket1.remote_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE ip::tcp::endpoint endpoint3 = socket1.remote_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE ip::tcp::endpoint endpoint4 = socket1.remote_endpoint(ec);
 
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);
@@ -915,8 +915,8 @@ void test()
     acceptor1.native_non_blocking(true);
     acceptor1.native_non_blocking(false, ec);
 
-    ip::tcp::endpoint endpoint1 = acceptor1.local_endpoint();
-    ip::tcp::endpoint endpoint2 = acceptor1.local_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE ip::tcp::endpoint endpoint1 = acceptor1.local_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE ip::tcp::endpoint endpoint2 = acceptor1.local_endpoint(ec);
 
     acceptor1.wait(socket_base::wait_read);
     acceptor1.wait(socket_base::wait_write, ec);

--- a/test/ip/udp.cpp
+++ b/test/ip/udp.cpp
@@ -246,11 +246,11 @@ void test()
     socket1.native_non_blocking(true);
     socket1.native_non_blocking(false, ec);
 
-    ip::udp::endpoint endpoint1 = socket1.local_endpoint();
-    ip::udp::endpoint endpoint2 = socket1.local_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE ip::udp::endpoint endpoint1 = socket1.local_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE ip::udp::endpoint endpoint2 = socket1.local_endpoint(ec);
 
-    ip::udp::endpoint endpoint3 = socket1.remote_endpoint();
-    ip::udp::endpoint endpoint4 = socket1.remote_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE ip::udp::endpoint endpoint3 = socket1.remote_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE ip::udp::endpoint endpoint4 = socket1.remote_endpoint(ec);
 
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);

--- a/test/local/datagram_protocol.cpp
+++ b/test/local/datagram_protocol.cpp
@@ -129,11 +129,11 @@ void test()
     socket1.io_control(io_control_command);
     socket1.io_control(io_control_command, ec);
 
-    dp::endpoint endpoint1 = socket1.local_endpoint();
-    dp::endpoint endpoint2 = socket1.local_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE dp::endpoint endpoint1 = socket1.local_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE dp::endpoint endpoint2 = socket1.local_endpoint(ec);
 
-    dp::endpoint endpoint3 = socket1.remote_endpoint();
-    dp::endpoint endpoint4 = socket1.remote_endpoint(ec);
+    BOOST_ASIO_UNUSED_VARIABLE dp::endpoint endpoint3 = socket1.remote_endpoint();
+    BOOST_ASIO_UNUSED_VARIABLE dp::endpoint endpoint4 = socket1.remote_endpoint(ec);
 
     socket1.shutdown(socket_base::shutdown_both);
     socket1.shutdown(socket_base::shutdown_both, ec);


### PR DESCRIPTION
Current msvc  enables [[nodiscard]] if using /std:c++17 and this causes warning in the buffer.hpp test code.
see https://docs.microsoft.com/en-us/cpp/cpp/attributes2
While testing the patch on gcc/clang suppressed some more unused variable warnings

